### PR TITLE
fix: force HTTPS on all generated links in production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,6 +19,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        if (env('APP_ENV') !== 'local') { // Solo en producción
+            URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
This PR implements the configuration to enforce the use of HTTPS for all generated links in the application, improving security and preventing mixed content issues.

Changes Included
Enforce HTTPS: Modified AppServiceProvider.php to force the HTTPS scheme in the production environment.
Configuration Updates: Ensured the necessary configurations are in place to guarantee that all resources load securely.
Reason
The addition of this configuration is essential to ensure that the application operates securely in production environments, preventing mixed content errors and ensuring that all generated links use HTTPS. This helps maintain the integrity and quality of the code as the project progresses.